### PR TITLE
Fixes old way of getting package config

### DIFF
--- a/src/Pingpong/Admin/Controllers/SiteController.php
+++ b/src/Pingpong/Admin/Controllers/SiteController.php
@@ -107,7 +107,7 @@ class SiteController extends BaseController
                            ->orWhere('slug', $id)
                            ->firstOrFail();
 
-            $view = \Config::get('admin::post.view');
+            $view = \Config::get('admin.views.post');
 
             return \View::make($view, compact('post'));
         } catch (ModelNotFoundException $e) {


### PR DESCRIPTION
In the service provider the old way (admin::path.views) was being used. This caused a View not found error being thrown. 