### PR TITLE
Fixed ckeditor path prefix.

### DIFF
--- a/src/views/articles/form.blade.php
+++ b/src/views/articles/form.blade.php
@@ -58,7 +58,7 @@
 	{!! script('vendor/ckfinder/ckfinder.js') !!}
 	
 	<script type="text/javascript">
-	  var prefix = '{!! asset(option("ckfinder.prefix")) !!}';
+		var prefix = '{!! asset(option("ckfinder.prefix")) !!}';
 		CKEDITOR.editorConfig = function( config ) {
 		   config.filebrowserBrowseUrl = prefix + '/vendor/ckfinder/ckfinder.html';
 		   config.filebrowserImageBrowseUrl = prefix + '/vendor/ckfinder/ckfinder.html?type=Images';

--- a/src/views/articles/form.blade.php
+++ b/src/views/articles/form.blade.php
@@ -58,9 +58,8 @@
 	{!! script('vendor/ckfinder/ckfinder.js') !!}
 	
 	<script type="text/javascript">
+	  var prefix = '{!! asset(option("ckfinder.prefix")) !!}';
 		CKEDITOR.editorConfig = function( config ) {
-			var prefix = '/{!! option("ckfinder.prefix") !!}';
-
 		   config.filebrowserBrowseUrl = prefix + '/vendor/ckfinder/ckfinder.html';
 		   config.filebrowserImageBrowseUrl = prefix + '/vendor/ckfinder/ckfinder.html?type=Images';
 		   config.filebrowserFlashBrowseUrl = prefix + '/vendor/ckfinder/ckfinder.html?type=Flash';
@@ -70,7 +69,6 @@
 		};
 
 		var editor = CKEDITOR.replace( 'ckeditor' );
-		var prefix = '/{!! option("ckfinder.prefix") !!}';
 		CKFinder.setupCKEditor( editor, prefix + '/vendor/ckfinder/') ;
 	</script>
 @stop


### PR DESCRIPTION
Use asset function to generate full path for ckeditor and ckfinder prefix, this can avoid url error on site in subdir.
